### PR TITLE
fix Internationalization example so that it matches with 5 min quick start

### DIFF
--- a/docs/assets/HelloWorld.ja.ts
+++ b/docs/assets/HelloWorld.ja.ts
@@ -6,7 +6,7 @@ HelloWorld.languages!.ja = {
   niceName: "世界のご案内",
   description: "非常に単純のプラグイン",
   commands: {
-    "Hello World": {
+    "Respond": {
       name: "ハロー・ワールド",
       match: "はろーわーるど",
     },


### PR DESCRIPTION
posted on the forum.
https://discuss.lipsurf.com/t/internationalized-hello-world-not-show-in-plugins-list/748/3

"comands" key in Internationalization example should be matched with 5 min quick start example's one so that we will not lost.

If I was wrong, I apologize in advanced.